### PR TITLE
Node 14 support: switch to napi

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var FFI = require('ffi-napi'),
-    ArrayType = require('ref-array'),
-    Struct = require('ref-struct'),
-    ref = require('ref');
+    ArrayType = require('ref-array-napi'),
+    Struct = require('ref-struct-napi'),
+    ref = require('ref-napi');
 
 var voidPtr = ref.refType(ref.types.void);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "author": "Coleman Nitroy",
   "devDependencies": {
-    "ffi-generate": "0.0.8"
+    "ffi-generate": "git+ssh://git@github.com:node-ffi-packager/node-ffi-generate.git"
   },
   "repository": {
     "type": "git",
@@ -15,10 +15,10 @@
     "url": "https://github.com/NitroPye/node-pdflib/issues"
   },
   "dependencies": {
-    "ffi-napi": "^2.4.5",
-    "ref": "^1.0.2",
-    "ref-array": "^1.1.1",
-    "ref-struct": "^1.0.1"
+    "ffi-napi": "^3.1.0",
+    "ref-napi": "^3.0.1",
+    "ref-array-napi": "^1.2.1",
+    "ref-struct-napi": "^1.1.1"
   },
   "keywords": [
     "pdf",


### PR DESCRIPTION
Support for new Nodes is done by switching from the regular version of "ref" and other packages (they are abandoned for a while) to N-API versions of the same libraries. They have to be "fully" compatible with old versions.
I've tested `paper` with them both for Node 10 & Node 14, both work fine.
Based on their compatibility version matrix (https://nodejs.org/docs/latest-v14.x/api/n-api.html#n_api_n_api_version_matrix) it would work fine with node version on staging & production (which is a bit outdated node@10).

More about N-API: https://nodejs.org/docs/latest-v14.x/api/n-api.html